### PR TITLE
Allow changing forceRefresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ const history = createBrowserHistory({
 })
 ```
 
+It's also possible to change this setting using `history.setForceRefresh(true)`.
+
 ### Modifying the Hash Type in createHashHistory
 
 By default `createHashHistory` uses a leading slash in hash-based URLs. You can use the `hashType` option to use a different hash formatting.

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -42,7 +42,6 @@ const createBrowserHistory = (props = {}) => {
   const needsHashChangeListener = !supportsPopStateOnHashChange();
 
   const {
-    forceRefresh = false,
     getUserConfirmation = getConfirmation,
     keyLength = 6
   } = props;
@@ -150,6 +149,11 @@ const createBrowserHistory = (props = {}) => {
   // Public interface
 
   const createHref = location => basename + createPath(location);
+
+  let {forceRefresh = false} = props;
+  const setForceRefresh = forceNextRefresh => {
+    forceRefresh = forceNextRefresh
+  }
 
   const push = (path, state) => {
     warning(
@@ -319,7 +323,8 @@ const createBrowserHistory = (props = {}) => {
     goBack,
     goForward,
     block,
-    listen
+    listen,
+    setForceRefresh,
   };
 
   return history;


### PR DESCRIPTION
# TL;DR https://codesandbox.io/s/n77x71v6x4

This has been discussed in #477. The [suggestion](https://github.com/ReactTraining/history/issues/477#issuecomment-307545239) then were to use `window.location.reload` when the user clicks on a link. Having tested this solution in production I feel this topic is worth a revisit 🤔 

The [codesandbox](https://codesandbox.io/s/n77x71v6x4) demonstrates the difference between using `window.location.reload` and having the option to set `forceRefresh` by calling `history.setForceRefresh` itself in a typical `react-router` setup.

Since the call to `window.location.reload` is async the page usually unloads after rendering the same route that is being navigated to, making it look like something went wrong to the end user:

![kapture 2018-08-04 at 19 56 26](https://user-images.githubusercontent.com/81981/43679290-219c4c3c-9823-11e8-86ee-2013935fb7b8.gif)

Compare it to `forceRefresh`: 

![kapture 2018-08-04 at 19 58 22](https://user-images.githubusercontent.com/81981/43679307-71092aba-9823-11e8-90c4-d71242745c14.gif)

I tried my best to find alternative solutions but doing something the equivalent of:
```jsx
import {Router} from 'react-router-dom';

const history = createBrowserHistory();
const forceRefreshHistory = createBrowserHistory({forceRefresh: true});

...
return <Router history={shouldForceRefresh ? forceRefreshHistory : history}>
```
Turned out to be surprisingly difficult. As was trying to wrap every `<Link />` and `<Redirect />` with custom logic that overrides events and essentially reimplement what `forceRefresh` in `history` does to achieve the same result. But as it turns out there's more logic than react components that might trigger a navigation events so this too is fragile (and a lot of code compared to just rendering a component somewhere wrapped in `withRouter` that calls `history.setForceRefresh(true)` and that's it).

What do you think?