### PR TITLE
improve: warn when state is provided in HashHistory

### DIFF
--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -46,6 +46,9 @@ describe('a hash history', () => {
       it('calls change listeners with the new location and emits a warning', done => {
         TestSequences.PushStateWarning(history, done);
       });
+      it('calls change listeners with the new location adn emits a warning (one arg)', done => {
+        TestSequences.PushOneArgStateWarning(history, done);
+      })
     });
 
     describe('push with no pathname', () => {
@@ -87,6 +90,9 @@ describe('a hash history', () => {
     describe('replace state', () => {
       it('calls change listeners with the new location and emits a warning', done => {
         TestSequences.ReplaceStateWarning(history, done);
+      });
+      it('calls change listeners with the new location and emits a warning (one arg)', done => {
+        TestSequences.ReplaceOneArgStateWarning(history, done);
       });
     });
 

--- a/modules/__tests__/TestSequences/PushOneArgStateWarning.js
+++ b/modules/__tests__/TestSequences/PushOneArgStateWarning.js
@@ -1,0 +1,42 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push({ pathname: '/home', state: { the: 'state' } });
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        hash: '',
+        search: '',
+        state: undefined
+      });
+
+      // We should see a warning message.
+      expect(warningMessage).toMatch(
+        'Hash history cannot push state; it is ignored'
+      );
+    }
+  ];
+
+  let consoleWarn = console.warn; // eslint-disable-line no-console
+  let warningMessage;
+
+  // eslint-disable-next-line no-console
+  console.warn = message => {
+    warningMessage = message;
+  };
+
+  execSteps(steps, history, (...args) => {
+    console.warn = consoleWarn; // eslint-disable-line no-console
+    done(...args);
+  });
+}

--- a/modules/__tests__/TestSequences/ReplaceOneArgStateWarning.js
+++ b/modules/__tests__/TestSequences/ReplaceOneArgStateWarning.js
@@ -1,0 +1,42 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.replace({ pathname: '/home', state: { the: 'state' } });
+    },
+    (location, action) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '',
+        hash: '',
+        state: undefined,
+      });
+
+      // We should see a warning message.
+      expect(warningMessage).toMatch(
+        'Hash history cannot replace state; it is ignored'
+      );
+    }
+  ];
+
+  let consoleWarn = console.warn; // eslint-disable-line no-console
+  let warningMessage;
+
+  // eslint-disable-next-line no-console
+  console.warn = message => {
+    warningMessage = message;
+  };
+
+  execSteps(steps, history, (...args) => {
+    console.warn = consoleWarn; // eslint-disable-line no-console
+    done(...args);
+  });
+}

--- a/modules/__tests__/TestSequences/index.js
+++ b/modules/__tests__/TestSequences/index.js
@@ -31,12 +31,14 @@ export { default as PushSamePath } from './PushSamePath';
 export { default as PushSamePathWarning } from './PushSamePathWarning';
 export { default as PushState } from './PushState';
 export { default as PushStateWarning } from './PushStateWarning';
+export { default as PushOneArgStateWarning } from './PushOneArgStateWarning';
 export { default as PushRelativePathname } from './PushRelativePathname';
 export { default as PushUnicodeLocation } from './PushUnicodeLocation';
 export { default as ReplaceNewLocation } from './ReplaceNewLocation';
 export { default as ReplaceSamePath } from './ReplaceSamePath';
 export { default as ReplaceState } from './ReplaceState';
 export { default as ReplaceStateWarning } from './ReplaceStateWarning';
+export { default as ReplaceOneArgStateWarning } from './ReplaceOneArgStateWarning';
 export {
   default as ReturnFalseTransitionHook
 } from './ReturnFalseTransitionHook';

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -182,6 +182,13 @@ function createHashHistory(props = {}) {
       state === undefined,
       'Hash history cannot push state; it is ignored'
     );
+    if (path && typeof path !== 'string') {
+      warning(
+        typeof path.state === 'undefined',
+        'Hash history cannot push state; it is ignored'
+      );
+      path.state = undefined;
+    }
 
     const action = 'PUSH';
     const location = createLocation(
@@ -236,6 +243,13 @@ function createHashHistory(props = {}) {
       state === undefined,
       'Hash history cannot replace state; it is ignored'
     );
+    if (path && typeof path !== 'string') {
+      warning(
+        typeof path.state === 'undefined',
+        'Hash history cannot replace state; it is ignored'
+      );
+      path.state = undefined;
+    }
 
     const action = 'REPLACE';
     const location = createLocation(


### PR DESCRIPTION
It's by design not allowed currently to provide `state` when push or replace in HashHistory. However, if `state` is provided in one argument (as property), there is no warning and state can be set.
Recommend to provide same behavior through all cases.