### PR TITLE
Remove trailing slashes when trailingSlash is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ createBrowserHistory({
   basename: '', // The base URL of the app (see below)
   forceRefresh: false, // Set true to force full page refreshes
   keyLength: 6, // The length of location.key
+  trailingSlash: true, // If false, it will remove trailing slashes.
   // A function to use to confirm navigation with the user (see below)
   getUserConfirmation: (message, callback) => callback(window.confirm(message))
 });

--- a/modules/__tests__/createHref-test.js
+++ b/modules/__tests__/createHref-test.js
@@ -24,6 +24,37 @@ describe('a browser history', () => {
     });
   });
 
+  describe('with trailing slashes removed', () => {
+    let history;
+    beforeEach(() => {
+      history = createBrowserHistory();
+    });
+
+    it('removes the trailing slashes from the url', () => {
+      const href = history.createHref(
+        {
+          pathname: '/',
+          search: '?the=query',
+          hash: '#the-hash'
+        },
+        false
+      );
+
+      expect(href).toEqual('/?the=query#the-hash');
+    });
+
+    it('removes the trailing slashes from the url', () => {
+      const href = history.createHref(
+        {
+          pathname: '/some-path/'
+        },
+        false
+      );
+
+      expect(href).toEqual('/some-path');
+    });
+  });
+
   describe('with a basename', () => {
     let history;
     beforeEach(() => {

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -43,6 +43,7 @@ function createBrowserHistory(props = {}) {
   const needsHashChangeListener = !supportsPopStateOnHashChange();
 
   const {
+    trailingSlash = true,
     forceRefresh = false,
     getUserConfirmation = getConfirmation,
     keyLength = 6
@@ -148,8 +149,14 @@ function createBrowserHistory(props = {}) {
 
   // Public interface
 
-  function createHref(location) {
-    return basename + createPath(location);
+  function createHref(location, trailingSlash) {
+    const url = basename + createPath(location);
+
+    if (trailingSlash === false) {
+      return stripTrailingSlash(url);
+    }
+
+    return url;
   }
 
   function push(path, state) {
@@ -173,7 +180,7 @@ function createBrowserHistory(props = {}) {
       ok => {
         if (!ok) return;
 
-        const href = createHref(location);
+        const href = createHref(location, trailingSlash);
         const { key, state } = location;
 
         if (canUseHistory) {
@@ -223,7 +230,7 @@ function createBrowserHistory(props = {}) {
       ok => {
         if (!ok) return;
 
-        const href = createHref(location);
+        const href = createHref(location, trailingSlash);
         const { key, state } = location;
 
         if (canUseHistory) {


### PR DESCRIPTION
This PR introduces a new property for `createBrowserHistory`. The reason of the PR is as follows:

1. If you have a basename like `/de`, or `/fr`
2. And your homepage is configured to display a language by default, even when the language is not present in the URL
3. And you're trying to link to your homepage

There will be a trailing slashed added to the url. The reason is simply because `createPath` will always return a `/` when the pathname is empty and `createHref` is simply appending the created path to the basename. 

This PR introduces the possibility to remove the ending slashes with a `trailingSlash` option passed to the `createBrowserHistory` function. By default it is true, which keeps the actual behaviour. When it is `false`, the `createHref` function will remove the trailing slashes. 