### PR TITLE
Remove redundant '?' from search in createLocation

### DIFF
--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -15,11 +15,14 @@ export function createLocation(path, state, key, currentLocation) {
 
     if (location.pathname === undefined) location.pathname = '';
 
-    if (location.search) {
-      if (location.search.charAt(0) !== '?')
-        location.search = '?' + location.search;
-    } else {
+    if (!location.search || location.search === '?') {
       location.search = '';
+    } else if (
+      typeof location.search === 'string' &&
+      location.search.charAt(0) !== '?'
+    ) {
+      // Prepends obligatory "?" to the search string if it's missed
+      location.search = '?' + location.search;
     }
 
     if (location.hash) {

--- a/modules/__tests__/createLocation-test.js
+++ b/modules/__tests__/createLocation-test.js
@@ -141,4 +141,47 @@ describe('createLocation', () => {
       expect(Object.keys(location)).not.toContain('key');
     });
   });
+
+  describe('search parameters', () => {
+    describe('given as a string', () => {
+      it("removes redundant '?' from search", () => {
+        expect(createLocation('/the/path?')).toMatchObject({
+          pathname: '/the/path',
+          search: ''
+        });
+
+        expect(createLocation('/the/path?#the-hash')).toMatchObject({
+          pathname: '/the/path',
+          search: '',
+          hash: '#the-hash'
+        });
+      });
+    });
+
+    describe('given as an object', () => {
+      it("removes redundant '?' from search", () => {
+        expect(
+          createLocation({
+            pathname: '/the/path',
+            search: '?'
+          })
+        ).toMatchObject({
+          pathname: '/the/path',
+          search: ''
+        });
+      });
+
+      it("prepends '?' to search if it's missed", () => {
+        expect(
+          createLocation({
+            pathname: '/the/path',
+            search: 'the=query'
+          })
+        ).toMatchObject({
+          pathname: '/the/path',
+          search: '?the=query'
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Here is a fix for an issue that is marked for 4.11 release in a following roadmap #689 and reported in the #701. It appears this issue is caused because of `createLocation` and not `createHref` as it is stated in the roadmap. The former was just copying it without modifying to the output. 

More in depth:
1. `Link` from `react-router-dom` calls `navigate` on click
```javascript
navigate() {
  // e.g. 'to' equals to { pathname: "/the/path", search: `?` }
  const location = resolveToLocation(to, context.location);
  const method = replace ? history.replace : history.push;

  // location descriptor is passed unchanged to corresponding history method
  // { pathname: "/the/path", search: `?` }
  method(location);
}
```
2. `history.push` or `history.replace` are called and here is some common code from theirs body
```javascript
// creates location from location descriptor passed from Link component
// path equals to { pathname: "/the/path", search: `?` }
const location = createLocation(path, state, createKey(), history.location);

// ... afterwards it sets location to the history state
setState({ action, location });
```
3. Since '?' wasn't cleaned anywhere it ended up in the next state and caused redundant refetches, rerenders etc.