### PR TITLE
allow numeric paths

### DIFF
--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -29,7 +29,7 @@ export enum Action {
  * A URL path including the pathname, search string, and hash. No URL protocol
  * or domain information should be part of a path.
  */
-export type Path = string;
+export type Path = string | number;
 
 /**
  * A URL pathname, beginning with a /.


### PR DESCRIPTION
This is useful since many APIs return numeric IDs and `history.pushState(null, null, 123)` works just fine.

```jsx
// instead of
<Link to={String(record.id)}>{record.name}</Link>

// you can now
<Link to={record.id}>{record.name}</Link>
```