### PR TITLE
Clear previous search and hash on push/replace with pathname only

### DIFF
--- a/packages/history/__tests__/TestSequences/PushNewLocation.js
+++ b/packages/history/__tests__/TestSequences/PushNewLocation.js
@@ -20,6 +20,18 @@ export default (history, done) => {
         state: null,
         key: expect.any(String)
       });
+
+      history.push('/other');
+    },
+    ({ action, location }) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/other',
+        search: '',
+        hash: '',
+        state: null,
+        key: expect.any(String)
+      });
     }
   ];
 

--- a/packages/history/__tests__/TestSequences/ReplaceNewLocation.js
+++ b/packages/history/__tests__/TestSequences/ReplaceNewLocation.js
@@ -20,6 +20,18 @@ export default (history, done) => {
         state: null,
         key: expect.any(String)
       });
+
+      history.replace('/other');
+    },
+    ({ action, location }) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/other',
+        search: '',
+        hash: '',
+        state: null,
+        key: expect.any(String)
+      });
     }
   ];
 

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -479,7 +479,9 @@ export function createBrowserHistory(
   function getNextLocation(to: To, state: State = null): Location {
     return readOnly<Location>({
       ...location,
-      ...(typeof to === 'string' ? parsePath(to) : to),
+      ...(typeof to === 'string'
+        ? { search: '', hash: '', ...parsePath(to) }
+        : to),
       state,
       key: createKey()
     });
@@ -724,7 +726,9 @@ export function createHashHistory(
   function getNextLocation(to: To, state: State = null): Location {
     return readOnly<Location>({
       ...location,
-      ...(typeof to === 'string' ? parsePath(to) : to),
+      ...(typeof to === 'string'
+        ? { search: '', hash: '', ...parsePath(to) }
+        : to),
       state,
       key: createKey()
     });
@@ -920,7 +924,9 @@ export function createMemoryHistory(
   function getNextLocation(to: To, state: State = null): Location {
     return readOnly<Location>({
       ...location,
-      ...(typeof to === 'string' ? parsePath(to) : to),
+      ...(typeof to === 'string'
+        ? { search: '', hash: '', ...parsePath(to) }
+        : to),
       state,
       key: createKey()
     });

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -1,0 +1,9 @@
+const path = require('path');
+const execSync = require('child_process').execSync;
+
+let config = path.resolve(__dirname, 'rollup/history.config.js');
+
+execSync(`rollup -w -c ${config}`, {
+  env: process.env,
+  stdio: 'inherit'
+});


### PR DESCRIPTION
When `history.push` or `history.replace` is called with string URL without `search` or `hash` part the ones from previous location are kept.

```
history.push('https://reacttraining.com/with-query?query=hello');

// https://reacttraining.com/with-query?query=hello -> This is OK
console.log(history.createHref(history.location));

// new route is pushed without search
history.push('https://reacttraining.com/no-query');

// https://reacttraining.com/no-query?query=hello -> Current result keeps the old search
console.log(history.createHref(history.location));
```

This change adds default empty values for `search` and `hash` which are replaced if `parsePath` function finds some.

If the previous `search` or `hash` have to be reused `PartialPath` object can be passed with omitted keys.