### PR TITLE
createPath: Prefix search and hash parts as needed.

### DIFF
--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -1080,6 +1080,12 @@ export function createPath({
   search = '',
   hash = ''
 }: PartialPath) {
+  if (search && search[0] !== '?'){
+    search = '?' + search;
+  }
+  if (hash && hash[0] !== '#'){
+    hash = '#' + hash;
+  }
   return pathname + search + hash;
 }
 


### PR DESCRIPTION
Fixes #813 by restoring the version 4 behavior.

This is technically a breaking change, but my interpretation is that the breaking change from v4 to v5 was not made intentionally. So this is just restoring the old (desired) behavior.