### PR TITLE
Force refresh on browser back navigation

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -177,11 +177,10 @@ function createBrowserHistory(props = {}) {
         const { key, state } = location;
 
         if (canUseHistory) {
-          globalHistory.pushState({ key, state }, null, href);
-
           if (forceRefresh) {
             window.location.href = href;
           } else {
+            globalHistory.pushState({ key, state }, null, href);
             const prevIndex = allKeys.indexOf(history.location.key);
             const nextKeys = allKeys.slice(
               0,


### PR DESCRIPTION
Calling globalHistory.pushState when forceRefresh is enabled
causes the document to be loaded from cache instead of reloaded.

This breaks forceRefresh when navigating backwards using the
browser's navigation buttons.

Now, we only call pushState if not in forceRefresh mode.

For more information, see this issue:
https://github.com/ReactTraining/history/issues/638#issuecomment-435545828