### PR TITLE
Support numeric `to`

### DIFF
--- a/packages/history/__tests__/create-path-test.js
+++ b/packages/history/__tests__/create-path-test.js
@@ -1,0 +1,62 @@
+import expect from 'expect';
+import { createPath } from 'history';
+
+describe('createPath', () => {
+  describe('given only a pathname', () => {
+    it('returns the pathname unchanged', () => {
+      let path = createPath({ pathname: 'https://google.com' });
+      expect(path).toBe('https://google.com');
+    });
+  });
+
+  describe('given a pathname and a search param', () => {
+    it('returns the constructed pathname', () => {
+      let path = createPath({
+        pathname: 'https://google.com',
+        search: '?something=cool'
+      });
+      expect(path).toBe('https://google.com?something=cool');
+    });
+  });
+
+  describe('given a pathname and a search param without ?', () => {
+    it('returns the constructed pathname', () => {
+      let path = createPath({
+        pathname: 'https://google.com',
+        search: 'something=cool'
+      });
+      expect(path).toBe('https://google.com?something=cool');
+    });
+  });
+
+  describe('given a pathname and a hash param', () => {
+    it('returns the constructed pathname', () => {
+      let path = createPath({
+        pathname: 'https://google.com',
+        hash: '#section-1'
+      });
+      expect(path).toBe('https://google.com#section-1');
+    });
+  });
+
+  describe('given a pathname and a hash param without #', () => {
+    it('returns the constructed pathname', () => {
+      let path = createPath({
+        pathname: 'https://google.com',
+        hash: 'section-1'
+      });
+      expect(path).toBe('https://google.com#section-1');
+    });
+  });
+
+  describe('given a full location object', () => {
+    it('returns the constructed pathname', () => {
+      let path = createPath({
+        pathname: 'https://google.com',
+        search: 'something=cool',
+        hash: '#section-1'
+      });
+      expect(path).toBe('https://google.com?something=cool#section-1');
+    });
+  });
+});

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -312,11 +312,11 @@ export interface MemoryHistory<S extends State = State> extends History<S> {
   index: number;
 }
 
-const readOnly: <T extends unknown>(obj: T) => T = __DEV__
-  ? obj => Object.freeze(obj)
-  : obj => obj;
+const readOnly: <T>(obj: T) => Readonly<T> = __DEV__
+  ? (obj) => Object.freeze(obj)
+  : (obj) => obj;
 
-function warning(cond: boolean, message: string) {
+function warning(cond: any, message: string) {
   if (!cond) {
     // eslint-disable-next-line no-console
     if (typeof console !== 'undefined') console.warn(message);
@@ -545,7 +545,7 @@ export function createBrowserHistory(
         window.addEventListener(BeforeUnloadEventType, promptBeforeUnload);
       }
 
-      return function() {
+      return function () {
         unblock();
 
         // Remove the beforeunload listener so the document may
@@ -582,9 +582,11 @@ export function createHashHistory(
   let globalHistory = window.history;
 
   function getIndexAndLocation(): [number, Location] {
-    let { pathname = '/', search = '', hash = '' } = parsePath(
-      window.location.hash.substr(1)
-    );
+    let {
+      pathname = '/',
+      search = '',
+      hash = ''
+    } = parsePath(window.location.hash.substr(1));
     let state = globalHistory.state || {};
     return [
       state.idx,
@@ -804,7 +806,7 @@ export function createHashHistory(
         window.addEventListener(BeforeUnloadEventType, promptBeforeUnload);
       }
 
-      return function() {
+      return function () {
         unblock();
 
         // Remove the beforeunload listener so the document may
@@ -845,7 +847,7 @@ export function createMemoryHistory(
   options: MemoryHistoryOptions = {}
 ): MemoryHistory {
   let { initialEntries = ['/'], initialIndex } = options;
-  let entries: Location[] = initialEntries.map(entry => {
+  let entries: Location[] = initialEntries.map((entry) => {
     let location = readOnly<Location>({
       pathname: '/',
       search: '',
@@ -1016,20 +1018,18 @@ function createEvents<F extends Function>(): Events<F> {
     },
     push(fn: F) {
       handlers.push(fn);
-      return function() {
-        handlers = handlers.filter(handler => handler !== fn);
+      return function () {
+        handlers = handlers.filter((handler) => handler !== fn);
       };
     },
     call(arg) {
-      handlers.forEach(fn => fn && fn(arg));
+      handlers.forEach((fn) => fn && fn(arg));
     }
   };
 }
 
 function createKey() {
-  return Math.random()
-    .toString(36)
-    .substr(2, 8);
+  return Math.random().toString(36).substr(2, 8);
 }
 
 /**

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -170,7 +170,7 @@ export interface Blocker<S extends State = State> {
  * `history.push` or `history.replace`. May be either a URL or the pieces of a
  * URL path.
  */
-export type To = string | PartialPath;
+export type To = string | number | PartialPath;
 
 /**
  * A history is an interface to the navigation stack. The history serves as the
@@ -434,14 +434,14 @@ export function createBrowserHistory(
     globalHistory.replaceState({ ...globalHistory.state, idx: index }, '');
   }
 
-  function createHref(to: To) {
-    return typeof to === 'string' ? to : createPath(to);
+  function createHref(to: To): string {
+    return normalizeHref(to);
   }
 
   function getNextLocation(to: To, state: State = null): Location {
     return readOnly<Location>({
       ...location,
-      ...(typeof to === 'string' ? parsePath(to) : to),
+      ...normalizePath(to),
       state,
       key: createKey()
     });
@@ -682,13 +682,13 @@ export function createHashHistory(
   }
 
   function createHref(to: To) {
-    return getBaseHref() + '#' + (typeof to === 'string' ? to : createPath(to));
+    return getBaseHref() + '#' + normalizeHref(to);
   }
 
   function getNextLocation(to: To, state: State = null): Location {
     return readOnly<Location>({
       ...location,
-      ...(typeof to === 'string' ? parsePath(to) : to),
+      ...normalizePath(to),
       state,
       key: createKey()
     });
@@ -877,14 +877,14 @@ export function createMemoryHistory(
   let listeners = createEvents<Listener>();
   let blockers = createEvents<Blocker>();
 
-  function createHref(to: To) {
-    return typeof to === 'string' ? to : createPath(to);
+  function createHref(to: To): string {
+    return normalizeHref(to);
   }
 
   function getNextLocation(to: To, state: State = null): Location {
     return readOnly<Location>({
       ...location,
-      ...(typeof to === 'string' ? parsePath(to) : to),
+      ...normalizePath(to),
       state,
       key: createKey()
     });
@@ -1049,12 +1049,21 @@ export function createPath({
   return pathname;
 }
 
+function normalizePath(path: To | PartialPath): PartialPath {
+  return typeof path === 'object' ? path : parsePath(String(path));
+}
+
+function normalizeHref(to: To | PartialPath) {
+  return typeof to === 'object' ? createPath(to) : String(to);
+}
+
 /**
  * Parses a string URL path into its separate pathname, search, and hash components.
  *
  * @see https://github.com/ReactTraining/history/tree/master/docs/api-reference.md#parsepath
  */
-export function parsePath(path: string) {
+export function parsePath(path: string): PartialPath {
+  path = String(path);
   let partialPath: PartialPath = {};
 
   if (path) {

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -1042,7 +1042,11 @@ export function createPath({
   search = '',
   hash = ''
 }: PartialPath) {
-  return pathname + search + hash;
+  if (search && search !== '?')
+    pathname += search.charAt(0) === '?' ? search : '?' + search;
+  if (hash && hash !== '#')
+    pathname += hash.charAt(0) === '#' ? hash : '#' + hash;
+  return pathname;
 }
 
 /**


### PR DESCRIPTION
Resolves the same issue as https://github.com/remix-run/history/pull/795, but quite a bit seems to have changed since that PR was opened. We need to tweak some of our type checking logic if we're going to parse numbers as potential paths.