### PR TITLE
Add tests for push/replace of partial paths

### DIFF
--- a/packages/history/__tests__/TestSequences/PushPartialPath.js
+++ b/packages/history/__tests__/TestSequences/PushPartialPath.js
@@ -1,0 +1,30 @@
+import expect from 'expect';
+
+import { execSteps } from './utils.js';
+
+export default (history, done) => {
+  let steps = [
+    ({ location }) => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push({
+        search: '?the=query',
+        hash: "#the-hash"
+      });
+    },
+    ({ action, location }) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/',
+        search: '?the=query',
+        hash: '#the-hash',
+        state: null,
+        key: expect.any(String)
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+};

--- a/packages/history/__tests__/TestSequences/ReplacePartialPath.js
+++ b/packages/history/__tests__/TestSequences/ReplacePartialPath.js
@@ -1,0 +1,30 @@
+import expect from 'expect';
+
+import { execSteps } from './utils.js';
+
+export default (history, done) => {
+  let steps = [
+    ({ location }) => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.replace({
+        search: '?the=query',
+        hash: "#the-hash"
+      });
+    },
+    ({ action, location }) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/',
+        search: '?the=query',
+        hash: '#the-hash',
+        state: null,
+        key: expect.any(String)
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+};


### PR DESCRIPTION
Closes issue #919. I've just added two new test sequences that call `push and `replace` with objects rather than strings.