### PR TITLE
Fix: ensureCleanWorkingDirectory fails with only newly added files in the working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /build/
 /fixtures/*/history.js
 

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "history",
-  "version": "5.1.1",
+  "version": "5.1.0",
   "description": "Manage session history with JavaScript",
   "author": "Remix Software <hello@remix.run>",
   "repository": "remix-run/history",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "history",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Manage session history with JavaScript",
   "author": "Remix Software <hello@remix.run>",
   "repository": "remix-run/history",

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -20,9 +20,8 @@ function ensureCleanWorkingDirectory() {
   let status = execSync(`git status --porcelain`)
     .toString()
     .trim();
-  let lines = status.split('\n');
   invariant(
-    lines.every(line => line === '' || line.startsWith('?')),
+    status === '',
     'Working directory is not clean. Please commit or stash your changes.'
   );
 }


### PR DESCRIPTION
## Description
I think it's a tiny bug. When there are only newly added files in the working directory, `npm run version` is not expected to fail in the `ensureCleanWorkingDirectory` step.

## Change
The trimmed output of `git status --porcelain` is an empty string if the working directory is clean for the next version number generation.