### PR TITLE
fix: import history from ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
   },
   "filesize": {
     "build/history/history.production.min.js": {
-      "none": "5 kB"
+      "none": "5.06 kB"
     },
     "build/history/umd/history.production.min.js": {
-      "none": "6 kB"
+      "none": "6.03 kB"
     }
   }
 }

--- a/scripts/rollup/history.config.js
+++ b/scripts/rollup/history.config.js
@@ -1,5 +1,4 @@
 import { babel } from '@rollup/plugin-babel';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import copy from 'rollup-plugin-copy';
 import prettier from 'rollup-plugin-prettier';
 import replace from '@rollup/plugin-replace';
@@ -37,7 +36,6 @@ const modules = [
         ],
         babelHelpers: 'runtime'
       }),
-      compiler(),
       copy({
         targets: [
           { src: 'README.md', dest: OUTPUT_DIR },
@@ -70,8 +68,7 @@ const modules = [
           presets: [['@babel/preset-env', { loose: true }]],
           plugins: ['babel-plugin-dev-expression'],
           babelHelpers: 'bundled'
-        }),
-        compiler()
+        })
       ].concat(PRETTY ? prettier({ parser: 'babel' }) : [])
     };
   })
@@ -103,8 +100,7 @@ const webModules = [
       replace({
         'process.env.NODE_ENV': JSON.stringify('development'),
         preventAssignment: false
-      }),
-      compiler()
+      })
     ].concat(PRETTY ? prettier({ parser: 'babel' }) : [])
   },
   {
@@ -133,7 +129,6 @@ const webModules = [
         'process.env.NODE_ENV': JSON.stringify('production'),
         preventAssignment: false
       }),
-      compiler(),
       terser({ ecma: 8, safari10: true })
     ].concat(PRETTY ? prettier({ parser: 'babel' }) : [])
   }
@@ -160,8 +155,7 @@ const globals = [
       replace({
         'process.env.NODE_ENV': JSON.stringify('development'),
         preventAssignment: false
-      }),
-      compiler()
+      })
     ].concat(PRETTY ? prettier({ parser: 'babel' }) : [])
   },
   {
@@ -185,7 +179,6 @@ const globals = [
         'process.env.NODE_ENV': JSON.stringify('production'),
         preventAssignment: false
       }),
-      compiler(),
       terser()
     ].concat(PRETTY ? prettier({ parser: 'babel' }) : [])
   }


### PR DESCRIPTION
Removing closure compiiler fixes the problem. The build is now much faster and the resulting file size difference is marginal.

The UMD production file size went from 6,105 bytes with closure compiler to 6,164 without it. We can afford 59 bytes to get ESM support.