### PR TITLE
Restore entries attribute in MemoryHistory interface

### DIFF
--- a/packages/history/__tests__/memory-test.js
+++ b/packages/history/__tests__/memory-test.js
@@ -27,6 +27,10 @@ describe('a memory history', () => {
     expect(typeof history.index).toBe('number');
   });
 
+  it('has an entries property', () => {
+    expect(Array.isArray(history.entries)).toBe(true);
+  });
+
   it('knows how to create hrefs', () => {
     const href = history.createHref({
       pathname: '/the/path',

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -315,6 +315,7 @@ export interface HashHistory extends History {}
  */
 export interface MemoryHistory extends History {
   readonly index: number;
+  readonly entries: Location[];
 }
 
 const readOnly: <T>(obj: T) => Readonly<T> = __DEV__
@@ -972,6 +973,9 @@ export function createMemoryHistory(
   let history: MemoryHistory = {
     get index() {
       return index;
+    },
+    get entries() {
+      return entries;
     },
     get action() {
       return action;


### PR DESCRIPTION
Would feature fix this https://github.com/remix-run/history/issues/828

This PR gives back the feature of `MemoryHistory.entries` which was available in version 4

Many people are dependent on this feature, mainly because it gives more control over memory history itself.

For example, we are running SPA in the SSR (company historical reasons). This means the SPA state is lost whenever a site is reloaded. In version `history@4` we are able to save entries from the history object and pass it to `initialEntries` of the `MemoryRouter` to seed it back to its previous state (controlled behavior).

In react-router@6 we are still able to access the `MemoryHistory` object with `UNSAFE_NavigationContext`, but not its entries. So we are not able to implement a controlled `MemoryRouter`.

If it was intentional to remove entries for API reasons, close this PR.

Thank you for your response.

