### PR TITLE
set initial memory history key to "default"

### DIFF
--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -857,13 +857,13 @@ export function createMemoryHistory(
   options: MemoryHistoryOptions = {}
 ): MemoryHistory {
   let { initialEntries = ["/"], initialIndex } = options;
-  let entries: Location[] = initialEntries.map((entry) => {
+  let entries: Location[] = initialEntries.map((entry, index) => {
     let location = readOnly<Location>({
       pathname: "/",
       search: "",
       hash: "",
       state: null,
-      key: createKey(),
+      key: index === 0 ? "default" : createKey(),
       ...(typeof entry === "string" ? parsePath(entry) : entry),
     });
 


### PR DESCRIPTION
Documentation states that the initial entry always has key `"default"`. However on memory history this is not the case.

We check that the key is `"default"` to set a default behavior when the user clicks a "back" button to go back to home, but arrived at the page from a direct link. This works perfectly in the browser, but failed in the test because the key was not "default" on MemoryRouter.