### PR TITLE
suggest to make 'createEvents' type friendley 

### DIFF
--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -1017,13 +1017,13 @@ function promptBeforeUnload(event: BeforeUnloadEvent) {
 
 type EventHandler = (...args: any[]) => any;
 
-type Events<F> = {
+type Events<F extends EventHandler> = {
   length: number;
   push: (fn: F) => () => void;
-  call: (arg: any) => void;
+  call: (...arg: Parameters<F>) => void;
 };
 
-function createEvents<F extends Function>(): Events<F> {
+function createEvents<F extends EventHandler>(): Events<F> {
   let handlers: F[] = [];
 
   return {
@@ -1036,8 +1036,8 @@ function createEvents<F extends Function>(): Events<F> {
         handlers = handlers.filter((handler) => handler !== fn);
       };
     },
-    call(arg) {
-      handlers.forEach((fn) => fn && fn(arg));
+    call(...arg) {
+      handlers.forEach((fn) => fn && fn(...arg));
     },
   };
 }

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -1015,6 +1015,8 @@ function promptBeforeUnload(event: BeforeUnloadEvent) {
   event.returnValue = "";
 }
 
+type EventHandler = (...args: any[]) => any;
+
 type Events<F> = {
   length: number;
   push: (fn: F) => () => void;


### PR DESCRIPTION
I was trying to create a custom event for experiment (like this #949)
but did some mistakes because the type was not clear little.

I didn't want to someother make same mistake, 
Help them see for themselves what they are doing.

so I added a type specification to help with type inference.

## It make improve type inference

|before (any)|after (inferred)|
|---|---|
|<img width="320" alt="image" src="https://user-images.githubusercontent.com/41747333/172910462-e08e707b-f2ac-4aab-af53-d7d9d85f7237.png">|<img width="315" alt="image" src="https://user-images.githubusercontent.com/41747333/172910950-c3264ce0-1fdc-4656-a75b-5927482f4b62.png">|
|<img width="316" alt="image" src="https://user-images.githubusercontent.com/41747333/172910665-322eca69-dd1a-4ae1-8325-3b418ebd12c5.png">|<img width="311" alt="image" src="https://user-images.githubusercontent.com/41747333/172909877-6125c2af-504f-4fa2-9d28-04198d93d885.png">|

##  + Additionally
multiple parameter passing is possible by this

```
call(...arg) {
  handlers.forEach((fn) => fn && fn(...arg));
}
```

|before|after|
|---|---|
|<img width="396" alt="image" src="https://user-images.githubusercontent.com/41747333/172913087-7ccab14e-4df2-48dd-8eb4-1284193f070f.png">|<img width="384" alt="image" src="https://user-images.githubusercontent.com/41747333/172912860-f10f2e78-707b-4532-831d-f46bc8bd54f9.png">|

### if you don't think need multi parameter, can change like this

- EventType
```typescript
type Events<F extends EventHandler> = {
  length: number;
  push: (fn: F) => () => void;
  call: (arg: Parameters<F>[0]) => void; // can change optional if need
};
```

- Events.call
```typescript
// ...
call(arg) {
  handlers.forEach((fn) => fn && fn(arg));
},
// ...
```

## Thank you

Please consider to this pull request!
and Thank you for providing a good ecosystem!