### PR TITLE
feat: Add index property to BrowserHistory, HashHistory and Update #957

### DIFF
--- a/packages/history/__tests__/TestSequences/BackButtonTransitionHook.js
+++ b/packages/history/__tests__/TestSequences/BackButtonTransitionHook.js
@@ -7,14 +7,16 @@ export default (history, done) => {
   let unblock;
 
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/home");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",
@@ -26,7 +28,8 @@ export default (history, done) => {
 
       window.history.go(-1);
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(0);
       expect(action).toBe("POP");
       expect(location).toMatchObject({
         pathname: "/",

--- a/packages/history/__tests__/TestSequences/BlockEverything.js
+++ b/packages/history/__tests__/TestSequences/BlockEverything.js
@@ -4,7 +4,8 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
@@ -13,6 +14,7 @@ export default (history, done) => {
 
       history.push("/home");
 
+      expect(history.index).toBe(0);
       expect(history.location).toMatchObject({
         pathname: "/",
       });

--- a/packages/history/__tests__/TestSequences/GoBack.js
+++ b/packages/history/__tests__/TestSequences/GoBack.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/home");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toEqual("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",
@@ -19,7 +21,8 @@ export default (history, done) => {
 
       history.back();
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(0);
       expect(action).toEqual("POP");
       expect(location).toMatchObject({
         pathname: "/",

--- a/packages/history/__tests__/TestSequences/GoForward.js
+++ b/packages/history/__tests__/TestSequences/GoForward.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/home");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toEqual("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",
@@ -19,7 +21,8 @@ export default (history, done) => {
 
       history.back();
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(0);
       expect(action).toEqual("POP");
       expect(location).toMatchObject({
         pathname: "/",
@@ -27,7 +30,8 @@ export default (history, done) => {
 
       history.forward();
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toEqual("POP");
       expect(location).toMatchObject({
         pathname: "/home",

--- a/packages/history/__tests__/TestSequences/PushMissingPathname.js
+++ b/packages/history/__tests__/TestSequences/PushMissingPathname.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/home?the=query#the-hash");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",
@@ -21,7 +23,8 @@ export default (history, done) => {
 
       history.push("?another=query#another-hash");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(2);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",

--- a/packages/history/__tests__/TestSequences/PushNewLocation.js
+++ b/packages/history/__tests__/TestSequences/PushNewLocation.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/home?the=query#the-hash");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",

--- a/packages/history/__tests__/TestSequences/PushRelativePathname.js
+++ b/packages/history/__tests__/TestSequences/PushRelativePathname.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/the/path?the=query#the-hash");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/the/path",
@@ -21,7 +23,8 @@ export default (history, done) => {
 
       history.push("../other/path?another=query#another-hash");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(2);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/other/path",

--- a/packages/history/__tests__/TestSequences/PushRelativePathnameWarning.js
+++ b/packages/history/__tests__/TestSequences/PushRelativePathnameWarning.js
@@ -4,14 +4,16 @@ import { execSteps, spyOn } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/the/path?the=query#the-hash");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/the/path",
@@ -29,7 +31,8 @@ export default (history, done) => {
 
       destroy();
     },
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(2);
       expect(location).toMatchObject({
         pathname: "../other/path",
         search: "?another=query",

--- a/packages/history/__tests__/TestSequences/PushSamePath.js
+++ b/packages/history/__tests__/TestSequences/PushSamePath.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/home");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",
@@ -19,7 +21,8 @@ export default (history, done) => {
 
       history.push("/home");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(2);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",
@@ -27,7 +30,8 @@ export default (history, done) => {
 
       history.back();
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toBe("POP");
       expect(location).toMatchObject({
         pathname: "/home",

--- a/packages/history/__tests__/TestSequences/PushState.js
+++ b/packages/history/__tests__/TestSequences/PushState.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.push("/home?the=query#the-hash", { the: "state" });
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(1);
       expect(action).toBe("PUSH");
       expect(location).toMatchObject({
         pathname: "/home",

--- a/packages/history/__tests__/TestSequences/ReplaceNewLocation.js
+++ b/packages/history/__tests__/TestSequences/ReplaceNewLocation.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.replace("/home?the=query#the-hash");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(0);
       expect(action).toBe("REPLACE");
       expect(location).toMatchObject({
         pathname: "/home",
@@ -23,7 +25,8 @@ export default (history, done) => {
 
       history.replace("/");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(0);
       expect(action).toBe("REPLACE");
       expect(location).toMatchObject({
         pathname: "/",

--- a/packages/history/__tests__/TestSequences/ReplaceSamePath.js
+++ b/packages/history/__tests__/TestSequences/ReplaceSamePath.js
@@ -6,14 +6,16 @@ export default (history, done) => {
   let prevLocation;
 
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.replace("/home");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(0);
       expect(action).toBe("REPLACE");
       expect(location).toMatchObject({
         pathname: "/home",
@@ -23,7 +25,8 @@ export default (history, done) => {
 
       history.replace("/home");
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(0);
       expect(action).toBe("REPLACE");
       expect(location).toMatchObject({
         pathname: "/home",

--- a/packages/history/__tests__/TestSequences/ReplaceState.js
+++ b/packages/history/__tests__/TestSequences/ReplaceState.js
@@ -4,14 +4,16 @@ import { execSteps } from "./utils.js";
 
 export default (history, done) => {
   let steps = [
-    ({ location }) => {
+    ({ index, location }) => {
+      expect(index).toBe(0);
       expect(location).toMatchObject({
         pathname: "/",
       });
 
       history.replace("/home?the=query#the-hash", { the: "state" });
     },
-    ({ action, location }) => {
+    ({ index, action, location }) => {
+      expect(index).toBe(0);
       expect(action).toBe("REPLACE");
       expect(location).toMatchObject({
         pathname: "/home",

--- a/packages/history/__tests__/TestSequences/utils.js
+++ b/packages/history/__tests__/TestSequences/utils.js
@@ -44,6 +44,7 @@ export function execSteps(steps, history, done) {
     unlisten = history.listen(execNextStep);
 
     execNextStep({
+      index: history.index,
       action: history.action,
       location: history.location,
     });

--- a/packages/history/__tests__/browser-test.js
+++ b/packages/history/__tests__/browser-test.js
@@ -24,6 +24,10 @@ describe("a browser history", () => {
     history = createBrowserHistory();
   });
 
+  it("has an index property", () => {
+    expect(typeof history.index).toBe("number");
+  });
+
   it("knows how to create hrefs from location objects", () => {
     const href = history.createHref({
       pathname: "/the/path",

--- a/packages/history/__tests__/hash-test.js
+++ b/packages/history/__tests__/hash-test.js
@@ -28,6 +28,10 @@ describe("a hash history", () => {
     history = createHashHistory();
   });
 
+  it("has an index property", () => {
+    expect(typeof history.index).toBe("number");
+  });
+
   it("knows how to create hrefs from location objects", () => {
     const href = history.createHref({
       pathname: "/the/path",


### PR DESCRIPTION
Add `index` property to `BrowserHistory`, `HashHistory` and corresponding `Update` https://github.com/remix-run/history/issues/957

Related discussion: https://github.com/remix-run/react-router/discussions/9114
