### PR TITLE
Add Constant Domain History

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -126,6 +126,9 @@ let history = createBrowserHistory();
 
 See [the Getting Started guide](getting-started.md) for more information.
 
+<a name="createconstantdomainhistory"></a>
+<a name="constantdomainhistory"></a>
+
 ### `createConstantDomainHistory`
 
 <details>
@@ -148,7 +151,7 @@ A constant domain history is similar to browser history, but it will block back 
 For security reasons, browsers block accessing the entries on the history stack itself, hence it is impossible to check upfront where history.back() and history.forward() will bring you.
 When using these functions in a web app you usually only want to navigate on the same app and avoid going back to a different domain.
 
-Examples of potentially unwanted scenario's:
+Examples of potentially unwanted scenarios:
 
 Imagine you've built a web app, with a navigation menu that contains a couple of links to various pages and a go back button that is supposed to go back to the previously visited page (on your app).
 
@@ -158,27 +161,29 @@ Imagine you've built a web app, with a navigation menu that contains a couple of
 
 #### Solution
 
-We can't access the history stack, but we do control the next location to navigate to. So on **every** redirect (push and replace) within your app, we set a flag `fromDomain` with the current domain in the [location state](https://developer.mozilla.org/en-US/docs/Web/API/History/state) (which is stored in the browser's history stack and hence persisted between reloads!). This flag is sufficient to know if the current location was reached from a page of your own web app and hence if it is safe to go back.
-If this flag is not set (or set to a different domain) it means the previously visited page was not from your own web app. Hence the [`history.back`](#history.back) will now return a flag if the back navigation was blocked or not. If it returns true (navigation was blocked) you can implement a safe fallback to navigate somehwere else (on your app).
+We can't access the history stack, but we do control the next location to navigate to. So on **every** redirect (push and replace) within your app, we set a flag `fromDomain` with the current domain in the [location state](https://developer.mozilla.org/en-US/docs/Web/API/History/state) (which is stored in the browser's history stack and hence persisted between reloads). This flag is sufficient to know if the current location was reached from a page of your own web app and hence if it is safe to go back.
+If this flag is not set (or set to a different domain) it means the previously visited page was not from your own web app. The [`history.back`](#history.back) function will now return a flag if the going back navigation was blocked or not. If it returns true (navigation was blocked) you can implement a safe fallback to navigate somewhere else (on your app).
 
 NOTE: This solution only works correctly if you set the `fromDomain` flag consistently from every redirect in your app. Hence it is required to create a singleton history object and **only** use these functions.
-To help with this you could add an ESLint rule that prohibits the direct usage of the native browser's history and location API.
+To help with this, an ESLint rule [`no-native-navigation`](../rules/no-native-navigation.js) was added that prohibits the direct usage of the native browser's history and location API.
 
 #### Limitation
 
-The history API also provides function to navigate an arbitrary amount of entries back or forth in the history stack. Since the above solution only gives you some knowledge what the direct predecessor of the current location is, the go(delta !== -1 ) and forward() functions will always return true and don't navigate.
+The history API also provides functions to navigate an arbitrary amount of entries back or forth in the history stack. Since the above solution only gives you some knowledge what the direct predecessor of the current location is, the go(delta !== -1 ) and forward() functions will always return true and don't navigate.
+
+#### Example
 
 ```ts
 import { createConstantDomainHistory } from "history";
 let history = createBrowserHistory();
 
-let blocked = history.back(); // go back, only if we will go back to the same domain
+let blocked = history.back(); // Go back, only if we will go back to the same domain.
 if (blocked) {
   history.push("/"); // Fallback in case going back was prevented.
 }
 
-blocked = history.forward(); // will always be blocked and return true
-blocked = history.go(-2); // will always be blocked and return true
+blocked = history.forward(); // Will always be blocked and return true
+blocked = history.go(-2); // Will always be blocked and return true
 ```
 
 <a name="createpath"></a>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,9 +14,10 @@ The history library provides an API for tracking application history using [loca
 
 ### Environments
 
-The history library includes support for three different "environments", or modes of operation.
+The history library includes support for four different "environments", or modes of operation.
 
 - [Browser history](#createbrowserhistory) is used in web apps
+- [Constant Domain history](#createconstantdomainhistory) is similar to browser history, but it will block back and forward navigation to a different domain.
 - [Hash history](#createhashhistory) is used in web apps where you don't want to/can't send the URL to the server for some reason
 - [Memory history](#creatememoryhistory) - is used in native apps and testing
 
@@ -79,7 +80,7 @@ See [the Getting Started guide](getting-started.md) for more information.
 
 ### `History`
 
-A `History` object represents the shared interface for `BrowserHistory`, `HashHistory`, and `MemoryHistory`.
+A `History` object represents the shared interface for `BrowserHistory`, `ConstantDomainHistory`, `HashHistory`, and `MemoryHistory`.
 
 <details>
   <summary>Type declaration</summary>
@@ -91,9 +92,9 @@ interface History {
   createHref(to: To): string;
   push(to: To, state?: any): void;
   replace(to: To, state?: any): void;
-  go(delta: number): void;
-  back(): void;
-  forward(): void;
+  go(delta: number): boolean;
+  back(): boolean;
+  forward(): boolean;
   listen(listener: Listener): () => void;
   block(blocker: Blocker): () => void;
 }
@@ -124,6 +125,61 @@ let history = createBrowserHistory();
 ```
 
 See [the Getting Started guide](getting-started.md) for more information.
+
+### `createConstantDomainHistory`
+
+<details>
+  <summary>Type declaration</summary>
+
+```tsx
+function createConstantDomainHistory(options?: {
+  window?: Window;
+}): ConstantDomainHistory;
+
+interface ConstantDomainHistory extends History {}
+```
+
+</details>
+
+A constant domain history is similar to browser history, but it will block back and forward navigation to a different domain.
+
+#### The Problem
+
+For security reasons, browsers block accessing the entries on the history stack itself, hence it is impossible to check upfront where history.back() and history.forward() will bring you.
+When using these functions in a web app you usually only want to navigate on the same app and avoid going back to a different domain.
+
+Examples of potentially unwanted scenario's:
+
+Imagine you've built a web app, with a navigation menu that contains a couple of links to various pages and a go back button that is supposed to go back to the previously visited page (on your app).
+
+- Start from a different page (e.g. google.com) > overwrite the url with the url of your app > press enter to load > press the go back button on your app => you will go back to google.com and there is no way to avoid that or to check if the previous history entry was from a different domain.
+- You implemented authentication with a 3rd party system. On the first visit you redirect to the authentication provider which will redirect you back to your web app after successfully logged in. Now press the go back button => you will go back to the login (success) page again even though you are already logged in.
+- You could try to keep your own history stack in memory, but this is lost when you refresh your browser. Also, this is unaware of any pages you visited before your own app. Hence it will never be an exact copy of your browser's real history stack.
+
+#### Solution
+
+We can't access the history stack, but we do control the next location to navigate to. So on **every** redirect (push and replace) within your app, we set a flag `fromDomain` with the current domain in the [location state](https://developer.mozilla.org/en-US/docs/Web/API/History/state) (which is stored in the browser's history stack and hence persisted between reloads!). This flag is sufficient to know if the current location was reached from a page of your own web app and hence if it is safe to go back.
+If this flag is not set (or set to a different domain) it means the previously visited page was not from your own web app. Hence the [`history.back`](#history.back) will now return a flag if the back navigation was blocked or not. If it returns true (navigation was blocked) you can implement a safe fallback to navigate somehwere else (on your app).
+
+NOTE: This solution only works correctly if you set the `fromDomain` flag consistently from every redirect in your app. Hence it is required to create a singleton history object and **only** use these functions.
+To help with this you could add an ESLint rule that prohibits the direct usage of the native browser's history and location API.
+
+#### Limitation
+
+The history API also provides function to navigate an arbitrary amount of entries back or forth in the history stack. Since the above solution only gives you some knowledge what the direct predecessor of the current location is, the go(delta !== -1 ) and forward() functions will always return true and don't navigate.
+
+```ts
+import { createConstantDomainHistory } from "history";
+let history = createBrowserHistory();
+
+let blocked = history.back(); // go back, only if we will go back to the same domain
+if (blocked) {
+  history.push("/"); // Fallback in case going back was prevented.
+}
+
+blocked = history.forward(); // will always be blocked and return true
+blocked = history.go(-2); // will always be blocked and return true
+```
 
 <a name="createpath"></a>
 <a name="parsepath"></a>
@@ -234,6 +290,7 @@ See also [`history.listen`](#history.listen).
 ### `history.back()`
 
 Goes back one entry in the history stack. Alias for `history.go(-1)`.
+Will return a boolean that indicates when the navigation was blocked or not.
 
 See [the Navigation guide](navigation.md) for more information.
 
@@ -284,6 +341,7 @@ the given destination.
 ### `history.forward()`
 
 Goes forward one entry in the history stack. Alias for `history.go(1)`.
+Will return a boolean that indicates when the navigation was blocked or not.
 
 See [the Navigation guide](navigation.md) for more information.
 
@@ -292,6 +350,7 @@ See [the Navigation guide](navigation.md) for more information.
 ### `history.go(delta: number)`
 
 Navigates back/forward by `delta` entries in the stack.
+Will return a boolean that indicates when the navigation was blocked or not.
 
 See [the Navigation guide](navigation.md) for more information.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,15 +7,16 @@ The history library provides history tracking and navigation primitives for Java
 
 If you haven't yet, please take a second to read through [the Installation guide](installation.md) to get the library installed and running on your system.
 
-We provide 3 different methods for working with history, depending on your environment:
+We provide 4 different methods for working with history, depending on your environment:
 
 - A "browser history" is for use in modern web browsers that support the [HTML5 history API](http://diveintohtml5.info/history.html) (see [cross-browser compatibility](http://caniuse.com/#feat=history))
+- A "constant domain history" is similar to browser history, but it will block back and forward navigation if it would redirect you to a different domain.
 - A "hash history" is for use in web browsers where you want to store the location in the [hash](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hash) portion of the current URL to avoid sending it to the server when the page reloads
 - A "memory history" is used as a reference implementation that may be used in non-browser environments, like [React Native](https://facebook.github.io/react-native/) or tests
 
-The main bundle exports one method for each environment: [`createBrowserHistory`](api-reference.md#createbrowserhistory) for browsers, [`createHashHistory`](api-reference.md#createhashhistory) for using hash history in browsers, and [`createMemoryHistory`](api-reference.md#creatememoryhistory) for creating an in-memory history.
+The main bundle exports one method for each environment: [`createBrowserHistory`](api-reference.md#createbrowserhistory) for browsers, [`createConstantDomainHistory`](api-reference.md#createconstantdomainHistory) for navigating on the same domain in browsers, [`createHashHistory`](api-reference.md#createhashhistory) for using hash history in browsers, and [`createMemoryHistory`](api-reference.md#creatememoryhistory) for creating an in-memory history.
 
-In addition to the main bundle, the library also includes `history/browser` and `history/hash` bundles that export singletons you can use to quickly get a history instance for [the current `document`](https://developer.mozilla.org/en-US/docs/Web/API/Window/document) (web page).
+In addition to the main bundle, the library also includes `history/browser`, `history/constantDomain` and `history/hash` bundles that export singletons you can use to quickly get a history instance for [the current `document`](https://developer.mozilla.org/en-US/docs/Web/API/Window/document) (web page).
 
 ## Basic Usage
 

--- a/packages/history/__tests__/constantDomain-test.js
+++ b/packages/history/__tests__/constantDomain-test.js
@@ -1,0 +1,177 @@
+import expect from "expect";
+import { createConstantDomainHistory } from "history";
+
+import PushNewLocation from "./TestSequences/PushNewLocation.js";
+import PushSamePath from "./TestSequences/PushSamePath.js";
+import PushState from "./TestSequences/PushState.js";
+import PushMissingPathname from "./TestSequences/PushMissingPathname.js";
+import PushRelativePathname from "./TestSequences/PushRelativePathname.js";
+import ReplaceNewLocation from "./TestSequences/ReplaceNewLocation.js";
+import ReplaceSamePath from "./TestSequences/ReplaceSamePath.js";
+import ReplaceState from "./TestSequences/ReplaceState.js";
+import EncodedReservedCharacters from "./TestSequences/EncodedReservedCharacters.js";
+import GoBack from "./TestSequences/GoBack.js";
+import BlockEverything from "./TestSequences/BlockEverything.js";
+import { execSteps } from "./TestSequences/utils.js";
+
+describe("a constant domain history", () => {
+  let history;
+  beforeEach(() => {
+    window.history.replaceState(null, null, "/");
+    history = createConstantDomainHistory();
+  });
+
+  describe("push a new path", () => {
+    it("calls change listeners with the new location", (done) => {
+      PushNewLocation(history, done);
+    });
+  });
+
+  describe("push the same path", () => {
+    it("calls change listeners with the new location", (done) => {
+      PushSamePath(history, done);
+    });
+  });
+
+  describe("push state", () => {
+    it("calls change listeners with the new location", (done) => {
+      PushState(history, done);
+    });
+  });
+
+  describe("push with no pathname", () => {
+    it("reuses the current location pathname", (done) => {
+      PushMissingPathname(history, done);
+    });
+  });
+
+  describe("push with a relative pathname", () => {
+    it("normalizes the pathname relative to the current location", (done) => {
+      PushRelativePathname(history, done);
+    });
+  });
+
+  describe("replace a new path", () => {
+    it("calls change listeners with the new location", (done) => {
+      ReplaceNewLocation(history, done);
+    });
+  });
+
+  describe("replace the same path", () => {
+    it("calls change listeners with the new location", (done) => {
+      ReplaceSamePath(history, done);
+    });
+  });
+
+  describe("replace state", () => {
+    it("calls change listeners with the new location", (done) => {
+      ReplaceState(history, done);
+    });
+  });
+
+  describe("location created with encoded/unencoded reserved characters", () => {
+    it("produces different location objects", (done) => {
+      EncodedReservedCharacters(history, done);
+    });
+  });
+
+  describe("back", () => {
+    it("calls change listeners with the previous location", (done) => {
+      GoBack(history, done);
+    });
+    it("avoid going back to a different domain (on initial route)", (done) => {
+      let steps = [
+        ({ action, location }) => {
+          expect(location).toMatchObject({
+            pathname: "/",
+          });
+
+          const blocked = history.back();
+          expect(blocked).toBeTruthy();
+        },
+      ];
+      execSteps(steps, history, done);
+    });
+    it("avoid going back to a different domain, after replace", (done) => {
+      let steps = [
+        ({ location }) => {
+          expect(location).toMatchObject({
+            pathname: "/",
+          });
+          history.replace("/home?the=query#the-hash", { the: "state" });
+        },
+        ({ action, location }) => {
+          expect(action).toBe("REPLACE");
+          expect(location).toMatchObject({
+            pathname: "/home",
+            search: "?the=query",
+            hash: "#the-hash",
+            state: { the: "state" },
+            key: expect.any(String),
+          });
+
+          const blocked = history.back();
+          expect(blocked).toBeTruthy();
+        },
+      ];
+      execSteps(steps, history, done);
+    });
+    it("avoid going back to a different domain, starting from a different domain", (done) => {
+      // TODO: how to test?
+      done();
+    });
+    it("go back after a reload", (done) => {
+      // TODO: how to test?
+      done();
+    });
+  });
+
+  describe("forward", () => {
+    it("forward is not allowed in constant domain history", (done) => {
+      let steps = [
+        ({ location }) => {
+          expect(location).toMatchObject({
+            pathname: "/",
+          });
+
+          history.push("/home");
+        },
+        ({ action, location }) => {
+          expect(action).toEqual("PUSH");
+          expect(location).toMatchObject({
+            pathname: "/home",
+          });
+
+          const blocked = history.back();
+          expect(blocked).toBeFalsy();
+        },
+        ({ action, location }) => {
+          expect(action).toEqual("POP");
+          expect(location).toMatchObject({
+            pathname: "/",
+          });
+
+          const blocked = history.forward();
+          expect(blocked).toBeTruthy();
+          expect(history.location).toMatchObject({
+            pathname: "/",
+          });
+        },
+      ];
+
+      execSteps(steps, history, done);
+    });
+  });
+
+  describe("block", () => {
+    it("blocks all transitions", (done) => {
+      BlockEverything(history, done);
+    });
+  });
+
+  // describe("block a POP without listening", () => {
+  //   it("receives the next ({ action, location })", (done) => {
+  //     BlockPopWithoutListening(history, done);
+  //   });
+  // });
+});

--- a/packages/history/constantDomain.ts
+++ b/packages/history/constantDomain.ts
@@ -1,0 +1,6 @@
+import { createConstantDomainHistory } from "history";
+
+/**
+ * Create a default instance for the current document.
+ */
+export default createConstantDomainHistory();

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -323,8 +323,8 @@ export interface MemoryHistory extends History {
 }
 
 /**
- * A constant domain history is similar to browser history, however it will block
- * back and forward navigation if it would redirect you to a different domain.
+ * A constant domain history is similar to browser history,
+ * but it will block back and forward navigation to a different domain.
  *
  * @see /docs/...
  */
@@ -1025,8 +1025,8 @@ export function createMemoryHistory(
 export type ConstantDomainHistoryOptions = { window?: Window };
 
 /**
- * A constant domain history is similar to browser history, however it will block
- * back and forward navigation if it would redirect you to a different domain.
+ * A constant domain history is similar to browser history,
+ * but it will block back and forward navigation to a different domain.
  *
  */
 export function createConstantDomainHistory(

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -326,7 +326,7 @@ export interface MemoryHistory extends History {
  * A constant domain history is similar to browser history,
  * but it will block back and forward navigation to a different domain.
  *
- * @see /docs/...
+ * @see /docs/api-reference.md#constantdomainhistory
  */
 export interface ConstantDomainHistory extends BrowserHistory {}
 
@@ -1028,12 +1028,13 @@ export type ConstantDomainHistoryOptions = { window?: Window };
  * A constant domain history is similar to browser history,
  * but it will block back and forward navigation to a different domain.
  *
+ * @see /docs/api-reference.md#constantdomainhistory
  */
 export function createConstantDomainHistory(
   options: BrowserHistoryOptions = {}
 ): BrowserHistory {
-  // TODO see if / how we can share common functionality with createBrowserHistory
-  // as most of this function is duplication only push, replace and go functions differ
+  // TODO see if / how we can share common functionality with createBrowserHistory,
+  // most of this function is duplication, only push, replace and go functions differ.
   let { window = document.defaultView! } = options;
   let globalHistory = window.history;
 
@@ -1210,16 +1211,16 @@ export function createConstantDomainHistory(
         false,
         `go(delta) with a delta != -1 cannot be used as it can't be verified you'll end up on the same domain`
       );
-      // return true to notify the navigation was blocked
+      // Return true to notify the navigation was blocked
       return true;
     }
     // In case go back 1 entry, check if we came from the same domain
     if (globalHistory.state?.fromDomain === window?.location.hostname) {
-      // It is safe to go back since we know we came from the same domain
+      // It is safe to go back
       globalHistory.go(delta);
       return false;
     } else {
-      // block going back to a different domain
+      // Block going back to a different domain
       return true;
     }
   }

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -239,10 +239,11 @@ export interface History {
    * current index. For example, a "back" navigation would use go(-1).
    *
    * @param delta - The delta in the stack index
+   * @returns blocked - A boolean that indicates if the navigation was blocked or not.
    *
    * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.go
    */
-  go(delta: number): void;
+  go(delta: number): boolean;
 
   /**
    * Navigates to the previous entry in the stack. Identical to go(-1).
@@ -250,16 +251,20 @@ export interface History {
    * Warning: if the current location is the first location in the stack, this
    * will unload the current document.
    *
+   * @returns blocked - A boolean that indicates if the navigation was blocked or not.
+   *
    * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.back
    */
-  back(): void;
+  back(): boolean;
 
   /**
    * Navigates to the next entry in the stack. Identical to go(1).
    *
+   * @returns blocked - A boolean that indicates if the navigation was blocked or not.
+   *
    * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.forward
    */
-  forward(): void;
+  forward(): boolean;
 
   /**
    * Sets up a listener that will be called whenever the current location
@@ -317,6 +322,14 @@ export interface MemoryHistory extends History {
   readonly index: number;
 }
 
+/**
+ * A constant domain history is similar to browser history, however it will block
+ * back and forward navigation if it would redirect you to a different domain.
+ *
+ * @see /docs/...
+ */
+export interface ConstantDomainHistory extends BrowserHistory {}
+
 const readOnly: <T>(obj: T) => Readonly<T> = __DEV__
   ? (obj) => Object.freeze(obj)
   : (obj) => obj;
@@ -346,6 +359,7 @@ type HistoryState = {
   usr: any;
   key?: string;
   idx: number;
+  fromDomain?: string;
 };
 
 const BeforeUnloadEventType = "beforeunload";
@@ -524,6 +538,7 @@ export function createBrowserHistory(
 
   function go(delta: number) {
     globalHistory.go(delta);
+    return false;
   }
 
   let history: BrowserHistory = {
@@ -538,10 +553,10 @@ export function createBrowserHistory(
     replace,
     go,
     back() {
-      go(-1);
+      return go(-1);
     },
     forward() {
-      go(1);
+      return go(1);
     },
     listen(listener) {
       return listeners.push(listener);
@@ -787,6 +802,7 @@ export function createHashHistory(
 
   function go(delta: number) {
     globalHistory.go(delta);
+    return false;
   }
 
   let history: HashHistory = {
@@ -801,10 +817,10 @@ export function createHashHistory(
     replace,
     go,
     back() {
-      go(-1);
+      return go(-1);
     },
     forward() {
-      go(1);
+      return go(1);
     },
     listen(listener) {
       return listeners.push(listener);
@@ -967,6 +983,8 @@ export function createMemoryHistory(
       index = nextIndex;
       applyTx(nextAction, nextLocation);
     }
+
+    return false;
   }
 
   let history: MemoryHistory = {
@@ -984,16 +1002,265 @@ export function createMemoryHistory(
     replace,
     go,
     back() {
-      go(-1);
+      return go(-1);
     },
     forward() {
-      go(1);
+      return go(1);
     },
     listen(listener) {
       return listeners.push(listener);
     },
     block(blocker) {
       return blockers.push(blocker);
+    },
+  };
+
+  return history;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Constant Domain History
+////////////////////////////////////////////////////////////////////////////////
+
+export type ConstantDomainHistoryOptions = { window?: Window };
+
+/**
+ * A constant domain history is similar to browser history, however it will block
+ * back and forward navigation if it would redirect you to a different domain.
+ *
+ */
+export function createConstantDomainHistory(
+  options: BrowserHistoryOptions = {}
+): BrowserHistory {
+  // TODO see if / how we can share common functionality with createBrowserHistory
+  // as most of this function is duplication only push, replace and go functions differ
+  let { window = document.defaultView! } = options;
+  let globalHistory = window.history;
+
+  function getIndexAndLocation(): [number, Location] {
+    let { pathname, search, hash } = window.location;
+    let state = globalHistory.state || {};
+    return [
+      state.idx,
+      readOnly<Location>({
+        pathname,
+        search,
+        hash,
+        state: state.usr || null,
+        key: state.key || "default",
+      }),
+    ];
+  }
+
+  let blockedPopTx: Transition | null = null;
+  function handlePop() {
+    if (blockedPopTx) {
+      blockers.call(blockedPopTx);
+      blockedPopTx = null;
+    } else {
+      let nextAction = Action.Pop;
+      let [nextIndex, nextLocation] = getIndexAndLocation();
+
+      if (blockers.length) {
+        if (nextIndex != null) {
+          let delta = index - nextIndex;
+          if (delta) {
+            // Revert the POP
+            blockedPopTx = {
+              action: nextAction,
+              location: nextLocation,
+              retry() {
+                go(delta * -1);
+              },
+            };
+
+            go(delta);
+          }
+        } else {
+          // Trying to POP to a location with no index. We did not create
+          // this location, so we can't effectively block the navigation.
+          warning(
+            false,
+            // TODO: Write up a doc that explains our blocking strategy in
+            // detail and link to it here so people can understand better what
+            // is going on and how to avoid it.
+            `You are trying to block a POP navigation to a location that was not ` +
+              `created by the history library. The block will fail silently in ` +
+              `production, but in general you should do all navigation with the ` +
+              `history library (instead of using window.history.pushState directly) ` +
+              `to avoid this situation.`
+          );
+        }
+      } else {
+        applyTx(nextAction);
+      }
+    }
+  }
+
+  window.addEventListener(PopStateEventType, handlePop);
+
+  let action = Action.Pop;
+  let [index, location] = getIndexAndLocation();
+  let listeners = createEvents<Listener>();
+  let blockers = createEvents<Blocker>();
+
+  if (index == null) {
+    index = 0;
+    globalHistory.replaceState({ ...globalHistory.state, idx: index }, "");
+  }
+
+  function createHref(to: To) {
+    return typeof to === "string" ? to : createPath(to);
+  }
+
+  // state defaults to `null` because `window.history.state` does
+  function getNextLocation(to: To, state: any = null): Location {
+    return readOnly<Location>({
+      pathname: location.pathname,
+      hash: "",
+      search: "",
+      ...(typeof to === "string" ? parsePath(to) : to),
+      state,
+      key: createKey(),
+    });
+  }
+
+  function getHistoryStateAndUrl(
+    nextLocation: Location,
+    index: number,
+    fromDomain?: string
+  ): [HistoryState, string] {
+    return [
+      {
+        usr: nextLocation.state,
+        key: nextLocation.key,
+        idx: index,
+        fromDomain,
+      },
+      createHref(nextLocation),
+    ];
+  }
+
+  function allowTx(action: Action, location: Location, retry: () => void) {
+    return (
+      !blockers.length || (blockers.call({ action, location, retry }), false)
+    );
+  }
+
+  function applyTx(nextAction: Action) {
+    action = nextAction;
+    [index, location] = getIndexAndLocation();
+    listeners.call({ action, location });
+  }
+
+  function push(to: To, state?: any) {
+    let nextAction = Action.Push;
+    let nextLocation = getNextLocation(to, state);
+    function retry() {
+      push(to, state);
+    }
+
+    if (allowTx(nextAction, nextLocation, retry)) {
+      // On push: always set the fromDomain prop to the current domain
+      let [historyState, url] = getHistoryStateAndUrl(
+        nextLocation,
+        index + 1,
+        window.location.hostname
+      );
+
+      // TODO: Support forced reloading
+      // try...catch because iOS limits us to 100 pushState calls :/
+      try {
+        globalHistory.pushState(historyState, "", url);
+      } catch (error) {
+        // They are going to lose state here, but there is no real
+        // way to warn them about it since the page will refresh...
+        window.location.assign(url);
+      }
+
+      applyTx(nextAction);
+    }
+  }
+
+  function replace(to: To, state?: any) {
+    let nextAction = Action.Replace;
+    let nextLocation = getNextLocation(to, state);
+    function retry() {
+      replace(to, state);
+    }
+
+    if (allowTx(nextAction, nextLocation, retry)) {
+      // On replace: retain the domain from the location to be replaced
+      let [historyState, url] = getHistoryStateAndUrl(
+        nextLocation,
+        index,
+        globalHistory.state?.fromDomain
+      );
+
+      // TODO: Support forced reloading
+      globalHistory.replaceState(historyState, "", url);
+
+      applyTx(nextAction);
+    }
+  }
+
+  function go(delta: number) {
+    if (delta !== -1) {
+      warning(
+        false,
+        `go(delta) with a delta != -1 cannot be used as it can't be verified you'll end up on the same domain`
+      );
+      // return true to notify the navigation was blocked
+      return true;
+    }
+    // In case go back 1 entry, check if we came from the same domain
+    if (globalHistory.state?.fromDomain === window?.location.hostname) {
+      // It is safe to go back since we know we came from the same domain
+      globalHistory.go(delta);
+      return false;
+    } else {
+      // block going back to a different domain
+      return true;
+    }
+  }
+
+  let history: BrowserHistory = {
+    get action() {
+      return action;
+    },
+    get location() {
+      return location;
+    },
+    createHref,
+    push,
+    replace,
+    go,
+    back() {
+      return go(-1);
+    },
+    forward() {
+      return go(1);
+    },
+    listen(listener) {
+      return listeners.push(listener);
+    },
+    block(blocker) {
+      let unblock = blockers.push(blocker);
+
+      if (blockers.length === 1) {
+        window.addEventListener(BeforeUnloadEventType, promptBeforeUnload);
+      }
+
+      return function () {
+        unblock();
+
+        // Remove the beforeunload listener so the document may
+        // still be salvageable in the pagehide event.
+        // See https://html.spec.whatwg.org/#unloading-documents
+        if (!blockers.length) {
+          window.removeEventListener(BeforeUnloadEventType, promptBeforeUnload);
+        }
+      };
     },
   };
 

--- a/rules/no-native-navigation.js
+++ b/rules/no-native-navigation.js
@@ -1,0 +1,48 @@
+module.exports = {
+  meta: {
+    fixable: false,
+    messages: {
+      unsafeFunction:
+        "'{{ func }}' is not allowed as it might break the constant domain router. Please use the history from 'history/constantDomain' instead.",
+    },
+  },
+
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (node.object.name === "window" && node.property.name === "history") {
+          context.report({
+            node,
+            messageId: "unsafeFunction",
+            data: { func: "window.history" },
+          });
+        }
+        if (
+          node.object.object?.name === "window" &&
+          node.object.property?.name === "location" &&
+          ["replace", "assign"].includes(node.property.name)
+        ) {
+          context.report({
+            node,
+            messageId: "unsafeFunction",
+            data: { func: `window.location.${node.property.name}` },
+          });
+        }
+      },
+      AssignmentExpression(node) {
+        if (
+          node.operator === "=" &&
+          node.left.object?.object?.name === "window" &&
+          node.left.object?.property?.name === "location" &&
+          node.left.property?.name === "href"
+        ) {
+          context.report({
+            node,
+            messageId: "unsafeFunction",
+            data: { func: `window.location.href =` },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
This PR adds a new 'Constant Domain History' object.

### Why
Currently when navigating back and forth with the history object, you don't know upfront where this will bring you. So you might as well end up on a different domain, which is often unexpected / unwanted. 

### What
The newly added history object prevents going back to a different domain.

### How
By setting a `fromDomain` flag in the history state. See the extended docs in this PR for further details.

### Impact
It slightly modifies the existing interface of the History object, but it is still backwards compatible. The navigation functions now return a boolean if the navigation was blocked or not.

### State
This is an initial PR, I don't expect it to get merged as is, but I'd love to gain some feedback / insights from the community!
