### PR TITLE
fix: createBrowserHistory() breaks history URL on iOS 11

### DIFF
--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -436,7 +436,7 @@ export function createBrowserHistory(
 
   if (index == null) {
     index = 0;
-    globalHistory.replaceState({ ...globalHistory.state, idx: index }, "");
+    globalHistory.replaceState({ ...globalHistory.state, idx: index }, "", createHref(location));
   }
 
   function createHref(to: To) {


### PR DESCRIPTION
fixes https://github.com/remix-run/history/issues/964