### PR TITLE
Fix/v4 open redirect CVE 2025 68470 v2

### DIFF
--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -1,5 +1,6 @@
 import resolvePathname from 'resolve-pathname';
 import valueEqual from 'value-equal';
+import warning from './warning.js';
 
 import { parsePath } from './PathUtils.js';
 
@@ -45,6 +46,20 @@ export function createLocation(path, state, key, currentLocation) {
     } else {
       throw e;
     }
+  }
+
+  // Security fix: Normalize embedded double-slashes to prevent open redirect vulnerability (CVE-2025-68470)
+  // Paths like "//evil.com" could be interpreted as protocol-relative URLs leading to external redirects
+  if (location.pathname && location.pathname.includes('//')) {
+    const oldPathname = location.pathname;
+    location.pathname = location.pathname.replace(/\/\/+/g, '/');
+    warning(
+      false,
+      'Pathnames cannot have embedded double slashes - normalizing ' +
+        oldPathname +
+        ' -> ' +
+        location.pathname
+    );
   }
 
   if (key) location.key = key;

--- a/modules/__tests__/createLocation-test.js
+++ b/modules/__tests__/createLocation-test.js
@@ -141,4 +141,108 @@ describe('createLocation', () => {
       expect(Object.keys(location)).not.toContain('key');
     });
   });
+
+  describe('with embedded double-slashes (security fix for CVE-2025-68470)', () => {
+    describe('given as a string', () => {
+      it('normalizes double slashes at the start to prevent open redirect', () => {
+        expect(createLocation('//evil.com/path')).toMatchObject({
+          pathname: '/evil.com/path',
+          search: '',
+          hash: ''
+        });
+      });
+
+      it('normalizes double slashes in the middle of the path', () => {
+        expect(createLocation('/the//path')).toMatchObject({
+          pathname: '/the/path',
+          search: '',
+          hash: ''
+        });
+      });
+
+      it('normalizes multiple consecutive slashes', () => {
+        expect(createLocation('///the////path///segment')).toMatchObject({
+          pathname: '/the/path/segment',
+          search: '',
+          hash: ''
+        });
+      });
+
+      it('normalizes double slashes while preserving search and hash', () => {
+        expect(createLocation('//evil.com/path?query=value#hash')).toMatchObject({
+          pathname: '/evil.com/path',
+          search: '?query=value',
+          hash: '#hash'
+        });
+      });
+
+      it('handles protocol-relative URLs that could redirect externally', () => {
+        expect(createLocation('//attacker.com')).toMatchObject({
+          pathname: '/attacker.com',
+          search: '',
+          hash: ''
+        });
+      });
+    });
+
+    describe('given as an object', () => {
+      it('normalizes double slashes at the start to prevent open redirect', () => {
+        expect(
+          createLocation({
+            pathname: '//evil.com/path',
+            search: '?the=query',
+            hash: '#the-hash'
+          })
+        ).toMatchObject({
+          pathname: '/evil.com/path',
+          search: '?the=query',
+          hash: '#the-hash'
+        });
+      });
+
+      it('normalizes double slashes in the middle of the path', () => {
+        expect(
+          createLocation({
+            pathname: '/the//path',
+            search: '?the=query',
+            hash: '#the-hash'
+          })
+        ).toMatchObject({
+          pathname: '/the/path',
+          search: '?the=query',
+          hash: '#the-hash'
+        });
+      });
+
+      it('normalizes multiple consecutive slashes', () => {
+        expect(
+          createLocation({
+            pathname: '///the////path'
+          })
+        ).toMatchObject({
+          pathname: '/the/path',
+          search: '',
+          hash: ''
+        });
+      });
+    });
+
+    describe('paths without double slashes', () => {
+      it('does not modify normal paths', () => {
+        expect(createLocation('/normal/path')).toMatchObject({
+          pathname: '/normal/path',
+          search: '',
+          hash: ''
+        });
+      });
+
+      it('does not modify paths with single slashes', () => {
+        expect(createLocation('/path/to/resource')).toMatchObject({
+          pathname: '/path/to/resource',
+          search: '',
+          hash: ''
+        });
+      });
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "history",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Manage session history with JavaScript",
   "repository": "ReactTraining/history",
   "license": "MIT",


### PR DESCRIPTION
 ## Summary

  This PR fixes a high-severity open redirect vulnerability (CVE-2025-68470) in the `history@4.x` package that affects all React Router v5 applications.
This work was co-authored by my coworkers Kevin Polson and Eric Boshart

  ## Vulnerability Details

  - **CVE**: CVE-2025-68470
  - **Snyk ID**: SNYK-JS-REACTROUTER-14908286
  - **Severity**: High (CVSS 7.1)
  - **Type**: Open Redirect (CWE-601)
  - **Affected Versions**: All versions < 6.30.2 (including all v4.x and v5.x)

  ### The Problem

  The `createLocation()` function in `modules/LocationUtils.js` does not validate paths with embedded double-slashes. This allows attackers to craft malicious URLs that redirect users to external sites:

  ```javascript
  // Vulnerable behavior
  createLocation('//evil.com') // → pathname: "//evil.com" (treated as protocol-relative URL)
  history.push('//attacker.com') // Redirects to external site
  <Link to="//evil.com" /> // Redirects externally
  <Redirect to="//attacker.com" /> // Redirects externally
 ```


  ### Solution

  This PR adds pathname normalization in createLocation() to collapse embedded double-slashes into single slashes:

 ```javascript
  // After fix
  createLocation('//evil.com') // → pathname: "/evil.com" (safe, internal path)
  createLocation('/path//to///resource') // → pathname: "/path/to/resource"
```


 ###  Key Changes:
  1. After pathname decoding, detect and normalize embedded double-slashes
  2. Replace consecutive slashes (/\/\/+/g) with single slash
  3. Emit development warning to guide developers to correct usage
  4. Maintains full backward compatibility

  ### Testing

  Test Coverage: 132/132 tests passing
  - All 122 existing tests continue to pass
  - 10 new security-specific tests added:


  ### References

  - Snyk Advisory: https://security.snyk.io/vuln/SNYK-JS-REACTROUTER-14908286
  - CWE-601: https://cwe.mitre.org/data/definitions/601.html
  - React Router v6 Fix: The vulnerability was fixed in react-router@6.30.2+, but v5 users cannot easily upgrade

